### PR TITLE
Don't put extern "C" around includes

### DIFF
--- a/libraries/SensEdu/src/SensEdu.h
+++ b/libraries/SensEdu/src/SensEdu.h
@@ -1,15 +1,16 @@
 #ifndef __SENSEDU_H__
 #define __SENSEDU_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include "libs.h"
 #include "adc.h"
 #include "dac.h"
 #include "timer.h"
 #include "dma.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef enum {
     SENSEDU_NO_ERRORS = 0x0000,

--- a/libraries/SensEdu/src/adc.h
+++ b/libraries/SensEdu/src/adc.h
@@ -1,11 +1,11 @@
 #ifndef __ADC_H__
 #define __ADC_H__
 
+#include "libs.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "libs.h"
 
 // redefine pure analog pins
 #define A8 (86u)

--- a/libraries/SensEdu/src/dac.h
+++ b/libraries/SensEdu/src/dac.h
@@ -1,11 +1,12 @@
 #ifndef __DAC_H__
 #define __DAC_H__
 
+
+#include "libs.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "libs.h"
 
 typedef enum {
     DAC_ERROR_NO_ERRORS = 0x00,

--- a/libraries/SensEdu/src/dma.h
+++ b/libraries/SensEdu/src/dma.h
@@ -1,12 +1,13 @@
 #ifndef __DMA_H__
 #define __DMA_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include "libs.h"
 #include "dac.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 // MPU calculations:
 //

--- a/libraries/SensEdu/src/libs.h
+++ b/libraries/SensEdu/src/libs.h
@@ -1,10 +1,6 @@
 #ifndef __LIBS_H__
 #define __LIBS_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <Arduino.h>
 
 #include "stm32h747xx.h"
@@ -17,9 +13,5 @@ extern "C" {
 #include "stm32h7xx_ll_cortex.h"
 #include "stm32h7xx_ll_rcc.h"
 #include "stm32h7xx_ll_pwr.h"
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif // __LIBS_H__

--- a/libraries/SensEdu/src/timer.h
+++ b/libraries/SensEdu/src/timer.h
@@ -1,11 +1,12 @@
 #ifndef __TIMER_H__
 #define __TIMER_H__
 
+
+#include "SensEdu.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "SensEdu.h"
 
 typedef enum {
     TIMER_ERROR_NO_ERRORS = 0x00,


### PR DESCRIPTION
Only put extern "C" around the prototypes of functions defined within each header.

If the first inclusion of a C++ library happens within an extern "C" block, it can cause linker errors as the code now references an unmangled symbol, but the real symbol is mangled by c++.